### PR TITLE
Allow the syntax to be changeable

### DIFF
--- a/src/jtml.js
+++ b/src/jtml.js
@@ -26,8 +26,10 @@ class JTML {
 		return Helpers.fn;
 	}
 
-	static config() {
-		console.log('TODO');
+	static config(options = {}) {
+		if (options.syntax) {
+			Compiler.changeSyntax(options.syntax);
+		}
 	}
 }
 


### PR DESCRIPTION
The standard syntax is `{{`, `{%`, `%}` and `}}`. However, many implementations are in other language environments, such as twig that have the same syntax.